### PR TITLE
rm `'jsdoc/no-undefined-types': 'off'` for js

### DIFF
--- a/eslint/js.js
+++ b/eslint/js.js
@@ -50,11 +50,6 @@ module.exports = {
     'jsdoc/match-description': 'off',
     'jsdoc/newline-after-description': 'error',
     'jsdoc/no-types': 'off',
-    // Note: no-undefined-types rule causes to many false positives:
-    // https://github.com/gajus/eslint-plugin-jsdoc/issues/559
-    // And it is also unaware of many built in types
-    // https://github.com/gajus/eslint-plugin-jsdoc/issues/280
-    'jsdoc/no-undefined-types': 'off',
     'jsdoc/require-returns-type': 'off',
     'jsdoc/require-description': 'off',
     'jsdoc/require-description-complete-sentence': 'off',


### PR DESCRIPTION
wrt the mentioned issues with this rule:
* https://github.com/gajus/eslint-plugin-jsdoc/issues/559 is resolved
* https://github.com/gajus/eslint-plugin-jsdoc/issues/280 - this seems like we can [use this workaround](https://github.com/gajus/eslint-plugin-jsdoc/issues/280#issuecomment-503789555) including configuration for common builtin types here in hd-scripts